### PR TITLE
Fix the bug that causes an infinite loop when the total number of fra…

### DIFF
--- a/train_codes/DataLoader.py
+++ b/train_codes/DataLoader.py
@@ -135,7 +135,7 @@ class Dataset(object):
             #随机选择某个video里
             vidname = self.all_videos[idx].split('/')[-1]
             video_imgs = self.all_img_names[idx]
-            if len(video_imgs) == 0:
+            if len(video_imgs) <= 11:
                 continue
             img_name = random.choice(video_imgs)
             img_idx = int(basename(img_name).split(".")[0])


### PR DESCRIPTION
…mes in the video does not exceed 11.

eg, the video has 11 frames, when select the NO.6 frame, `while abs(random_element - img_idx) <= 5:` will result in an infinite loop