### PR TITLE
Add import copy to blending.py

### DIFF
--- a/musetalk/utils/blending.py
+++ b/musetalk/utils/blending.py
@@ -1,6 +1,7 @@
 from PIL import Image
 import numpy as np
 import cv2
+import copy
 from face_parsing import FaceParsing
 
 fp = FaceParsing()


### PR DESCRIPTION
Commit f051221f76437c83f7ef61ed7f1a9788396e16c2 added a copy.deepcopy command without a corresponding import copy to the file.

This fixes that oversight.